### PR TITLE
Hide all Nameless units except for leaders as default

### DIFF
--- a/Nameless.cat
+++ b/Nameless.cat
@@ -598,7 +598,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="30.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fcb2-95b9-2fe1-8a10" name="Inker" book="Deadzone: Outbreak" page="57" hidden="false" collective="false" type="unit">
+    <selectionEntry id="fcb2-95b9-2fe1-8a10" name="Inker" book="Deadzone: Outbreak" page="57" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="69f6-b4fc-109d-cfd7" name="Inker" book="Deadzone: Outbreak" page="57" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -706,7 +706,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="8.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="dc6b-9530-7a96-541a" name="Scuttler" book="Deadzone: Outbreak" page="57" hidden="false" collective="false" type="unit">
+    <selectionEntry id="dc6b-9530-7a96-541a" name="Scuttler" book="Deadzone: Outbreak" page="57" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="2171-408f-b2a0-383f" name="Scuttler" book="Deadzone: Outbreak" page="57" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -830,7 +830,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="8.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7812-3aba-aacd-ec88" name="Caratid" book="Deadzone: Outbreak" page="57" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7812-3aba-aacd-ec88" name="Caratid" book="Deadzone: Outbreak" page="57" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="626b-ea6e-8f3a-0460" name="Caratid" book="Deadzone: Outbreak" page="57" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -985,7 +985,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="9.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d3d2-f9e1-1983-7388" name="Assassin" book="Deadzone: Outbreak" page="58" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d3d2-f9e1-1983-7388" name="Assassin" book="Deadzone: Outbreak" page="58" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="c2b7-f84b-cb03-1e79" name="Assassin" book="Deadzone: Outbreak" page="58" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -1088,7 +1088,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="17.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="588c-ab15-5c68-2053" name="Needle Drones" book="Deadzone: Outbreak" page="58" hidden="false" collective="false" type="unit">
+    <selectionEntry id="588c-ab15-5c68-2053" name="Needle Drones" book="Deadzone: Outbreak" page="58" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="7ec1-2171-5b42-9e9e" name="Needle Drones" book="Deadzone: Outbreak" page="58" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -1196,7 +1196,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2f69-f810-ef4a-54a6" name="Gunslinger" book="Deadzone: Outbreak" page="58" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2f69-f810-ef4a-54a6" name="Gunslinger" book="Deadzone: Outbreak" page="58" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="cc89-8faf-9134-40c3" name="Gunslinger" book="Deadzone: Outbreak" page="58" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -1343,7 +1343,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5e0a-a8f1-23bc-b5b4" name="Ogre" book="Deadzone: Outbreak" page="58" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5e0a-a8f1-23bc-b5b4" name="Ogre" book="Deadzone: Outbreak" page="58" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="f2b7-a142-53e5-89da" name="Ogre" book="Deadzone: Outbreak" page="58" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -1469,7 +1469,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3258-7490-771a-2a32" name="The Terror" book="Deadzone: Outbreak" page="59" hidden="false" collective="false" type="unit">
+    <selectionEntry id="3258-7490-771a-2a32" name="The Terror" book="Deadzone: Outbreak" page="59" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="5308-930c-1f0e-15c9" name="The Terror" book="Deadzone: Outbreak" page="59" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -1577,7 +1577,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="24.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="559a-dddd-fd9a-86f0" name="Rifleman" book="Deadzone: Outbreak" page="59" hidden="false" collective="false" type="unit">
+    <selectionEntry id="559a-dddd-fd9a-86f0" name="Rifleman" book="Deadzone: Outbreak" page="59" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="2052-fe9a-3b40-2b22" name="Rifleman" book="Deadzone: Outbreak" page="59" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -1730,7 +1730,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c453-c6cd-540a-c036" name="Bathomite" book="Deadzone: Outbreak" page="59" hidden="false" collective="false" type="unit">
+    <selectionEntry id="c453-c6cd-540a-c036" name="Bathomite" book="Deadzone: Outbreak" page="59" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="7400-7517-e4f9-335e" name="Bathomite" book="Deadzone: Outbreak" page="59" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -1925,7 +1925,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="27.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="67b1-920f-7c13-34de" name="Goliath" book="Deadzone: Outbreak" page="59" hidden="false" collective="false" type="unit">
+    <selectionEntry id="67b1-920f-7c13-34de" name="Goliath" book="Deadzone: Outbreak" page="59" hidden="true" collective="false" type="unit">
       <profiles>
         <profile id="f8e7-4a3d-867d-626b" name="Goliath" book="Deadzone: Outbreak" page="59" hidden="false" profileTypeId="bd3d-1b17-592d-9a6f" profileTypeName="Unit">
           <profiles/>
@@ -2080,7 +2080,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="48.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fe7a-0e64-68b0-e267" name="Chief Radgrad" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fe7a-0e64-68b0-e267" name="Chief Radgrad" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2145,7 +2145,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2a18-327b-f3f6-9836" name="Boomer, Grenadier" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2a18-327b-f3f6-9836" name="Boomer, Grenadier" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2210,7 +2210,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5806-8368-8b14-8128" name="The Helfather" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5806-8368-8b14-8128" name="The Helfather" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2275,7 +2275,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6991-6ee7-e3bf-d89e" name="Freya" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6991-6ee7-e3bf-d89e" name="Freya" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2340,7 +2340,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="10b9-a697-eed8-8cb0" name="Nastanza" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="10b9-a697-eed8-8cb0" name="Nastanza" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2405,7 +2405,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="32c2-2dd1-f15c-93a2" name="Wrath" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="32c2-2dd1-f15c-93a2" name="Wrath" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2470,7 +2470,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fee0-2d8a-3a4d-7c53" name="Chovar Psychic" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fee0-2d8a-3a4d-7c53" name="Chovar Psychic" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2535,7 +2535,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b002-534f-5675-9e6d" name="The Survivor" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b002-534f-5675-9e6d" name="The Survivor" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2600,7 +2600,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d409-c281-57e5-fb8c" name="Project Oberon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d409-c281-57e5-fb8c" name="Project Oberon" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2665,7 +2665,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4e02-f949-b482-66be" name="Blaine" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4e02-f949-b482-66be" name="Blaine" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2730,7 +2730,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1c27-7d06-6412-e405" name="Blaine on Jetbike" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1c27-7d06-6412-e405" name="Blaine on Jetbike" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2795,7 +2795,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="35b8-ac1d-438c-65ba" name="Teraton Shock Trooper" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="35b8-ac1d-438c-65ba" name="Teraton Shock Trooper" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2860,7 +2860,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9805-b55f-58a3-1a03" name="Ogre Terminator" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="9805-b55f-58a3-1a03" name="Ogre Terminator" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2925,7 +2925,7 @@
         <cost name="pts" costTypeId="61f9-fd84-cb0b-0306" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d51c-6f92-5dda-5eb0" name="Hund Rebel Bounty Hunter" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d51c-6f92-5dda-5eb0" name="Hund Rebel Bounty Hunter" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>


### PR DESCRIPTION
Makes units available depending on current leader. That's how it is supposed to be right?