### PR TITLE
Fixing Plague and adding new units

### DIFF
--- a/Plague 3rd Edition.cat
+++ b/Plague 3rd Edition.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a1e5-e343-cebd-f619" name="Plague" revision="1" battleScribeVersion="2.03" authorName="James Moyon" library="false" gameSystemId="914e-8a95-25ac-174f" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a1e5-e343-cebd-f619" name="Plague" revision="2" battleScribeVersion="2.03" authorName="James Moyon" library="false" gameSystemId="914e-8a95-25ac-174f" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <readme>Mantic and Deadzone and all associated characters, names, places and things are TM and Copyright Mantic Entertainment 2021.
 
 Please consider supporting Mantic by purchasing a subscription to the EasyArmy army builder at https://mantic.easyarmy.com/</readme>
@@ -13,20 +13,20 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="f6eb-31ea-9043-142a" name="Special Order: Mutation" hidden="false" targetId="1417-894f-f014-85a1" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3130-80b1-06c7-f945" name="New CategoryLink" hidden="false" targetId="93f0-5c07-b9f5-ed97" primary="true"/>
+        <categoryLink id="3130-80b1-06c7-f945" name="Leader" hidden="false" targetId="93f0-5c07-b9f5-ed97" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9e36-b08d-c831-0ae5" name="Teeth and Claws" hidden="false" collective="false" import="true" targetId="8e56-1896-cca4-feae" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efdd-c520-def0-e98b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38ac-fc1b-bb49-f484" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efdd-c520-def0-e98b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38ac-fc1b-bb49-f484" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="7358-e098-9f65-460a" name="Equipment" hidden="false" collective="false" import="true" targetId="7ff8-5aa1-f173-1e4b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="36.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="36"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cae7-bd78-ea48-0a40" name="Stage 3A &apos;General&apos;" hidden="false" collective="false" import="true" type="model">
@@ -37,26 +37,26 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="a968-3820-80c9-9c54" name="Special Order: Infection" hidden="false" targetId="636e-38e9-fe13-ff51" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d2b2-025b-9dff-442d" name="New CategoryLink" hidden="false" targetId="93f0-5c07-b9f5-ed97" primary="true"/>
+        <categoryLink id="d2b2-025b-9dff-442d" name="Leader" hidden="false" targetId="93f0-5c07-b9f5-ed97" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="cac3-08df-c717-06eb" name="Pistol" hidden="false" collective="false" import="true" targetId="c650-a3cb-6a61-4736" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a3d-94e3-5639-fc16" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af4a-e25b-6c13-1b61" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a3d-94e3-5639-fc16" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af4a-e25b-6c13-1b61" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="9ca4-384d-35b5-bd38" name="Equipment" hidden="false" collective="false" import="true" targetId="7ff8-5aa1-f173-1e4b" type="selectionEntryGroup"/>
         <entryLink id="c32f-df6b-31a3-5d7d" name="Combat Knife" hidden="false" collective="false" import="true" targetId="e6b8-61b0-e119-4ae3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="171b-0660-d934-6bf5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21df-aa49-7320-d902" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="171b-0660-d934-6bf5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21df-aa49-7320-d902" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="18.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="18"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="96a3-95f4-d937-95ab" name="Stage 2A &apos;Sentient&apos;" hidden="false" collective="false" import="true" type="model">
@@ -68,20 +68,20 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="f74e-eeb5-83e6-200b" name="Special Order: Thirst for Blood" hidden="false" targetId="6822-80d5-5c7a-90bd" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a1b4-f012-ae4b-1a2e" name="New CategoryLink" hidden="false" targetId="93f0-5c07-b9f5-ed97" primary="true"/>
+        <categoryLink id="a1b4-f012-ae4b-1a2e" name="Leader" hidden="false" targetId="93f0-5c07-b9f5-ed97" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="2e3a-c6d4-e7e3-0e0f" name="Teeth and Claws" hidden="false" collective="false" import="true" targetId="4762-b9e0-07f0-757a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed27-0594-7ce0-09d3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="102f-6c7c-e913-fd1c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed27-0594-7ce0-09d3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="102f-6c7c-e913-fd1c" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="9a5f-487c-67d5-0757" name="Equipment" hidden="false" collective="false" import="true" targetId="7ff8-5aa1-f173-1e4b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="26.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="26"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca81-4129-9985-7994" name="Stage 3A &apos;Ghoul&apos;" hidden="false" collective="false" import="true" type="model">
@@ -90,28 +90,51 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="8772-46e1-cf86-4156" name="Hacker" hidden="false" targetId="a546-aaa9-c4fe-7b42" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a0ad-5aa1-a445-8776" name="New CategoryLink" hidden="false" targetId="359c-fce2-04fc-93b1" primary="true"/>
+        <categoryLink id="a0ad-5aa1-a445-8776" name="Troop" hidden="false" targetId="359c-fce2-04fc-93b1" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3bac-4785-ca93-574a" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="01b5-145b-1b3c-b8c6">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5d0-ea8e-fc68-5973" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b021-f1a4-ed9c-04b8" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5d0-ea8e-fc68-5973" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b021-f1a4-ed9c-04b8" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="01b5-145b-1b3c-b8c6" name="Rifle" hidden="false" collective="false" import="true" targetId="87b3-96a5-3e35-5725" type="selectionEntry">
               <costs>
-                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="10.0"/>
-                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1.0"/>
+                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="8"/>
+                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="6319-36a0-1f89-43f8" name="Flamethrower" hidden="false" collective="false" import="true" targetId="2732-7f8f-9b7f-260d" type="selectionEntry">
               <costs>
-                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="10.0"/>
-                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1.0"/>
+                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="10"/>
+                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
               </costs>
             </entryLink>
           </entryLinks>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Metal Bar &amp; Pistol" hidden="false" id="f830-db02-1d9c-2c83">
+              <infoLinks>
+                <infoLink name="Metal Bar" id="b232-6c09-105e-cc50" hidden="false" type="profile" targetId="497c-0e9c-56d0-4997"/>
+                <infoLink name="Knockback" id="6de3-9045-7da0-32f3" hidden="false" type="rule" targetId="bddf-77c1-55be-e183"/>
+                <infoLink name="Pistol" id="197d-a449-c430-95f5" hidden="false" type="profile" targetId="e454-b5bf-2ed6-53a3"/>
+              </infoLinks>
+              <costs>
+                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="9"/>
+                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Vicious Two-Hander" hidden="false" id="39ec-8b0c-0701-863c">
+              <infoLinks>
+                <infoLink name="Vicious Two-Hander" id="1d7d-09ab-9f8a-7715" hidden="false" type="profile" targetId="3376-b52d-9054-4152"/>
+                <infoLink name="Smash (n)" id="a62e-17fb-82a8-8fb7" hidden="false" type="rule" targetId="3948-3af5-4928-3965"/>
+              </infoLinks>
+              <costs>
+                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="12"/>
+                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -124,26 +147,35 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="2710-727c-98a9-7808" name="Hacker" hidden="false" targetId="a546-aaa9-c4fe-7b42" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="853b-b2f9-c9b7-e55b" name="New CategoryLink" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
+        <categoryLink id="853b-b2f9-c9b7-e55b" name="Specialist" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1cb8-3103-558d-3a7d" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="72f4-31de-e974-697a">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c50b-3d71-ff4e-52cd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0372-7fb8-a23e-7261" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c50b-3d71-ff4e-52cd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0372-7fb8-a23e-7261" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="c589-9ca9-f79b-712f" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="471c-55ed-c6b7-592e" type="selectionEntry">
               <costs>
-                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="15.0"/>
-                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2.0"/>
+                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="15"/>
+                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2"/>
               </costs>
             </entryLink>
             <entryLink id="72f4-31de-e974-697a" name="HMG" hidden="false" collective="false" import="true" targetId="6315-4778-ce1d-0f1f" type="selectionEntry">
               <costs>
-                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="12.0"/>
-                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1.0"/>
+                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="12"/>
+                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
               </costs>
+            </entryLink>
+            <entryLink import="true" name="Pox Bomb" hidden="false" id="5d07-66c8-994d-bb24" type="selectionEntry" targetId="faec-30a9-7073-2dda">
+              <costs>
+                <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="13"/>
+                <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
+              </costs>
+              <infoLinks>
+                <infoLink name="Tools" id="1de4-3f29-14cf-9065" hidden="false" type="profile" targetId="7147-9f95-5fb4-c5a0"/>
+              </infoLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -158,19 +190,19 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="d76e-9642-2eef-849a" name="Beast" hidden="false" targetId="9dfa-4b05-f18a-4b11" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="67bd-8c4f-eee0-401e" name="New CategoryLink" hidden="false" targetId="359c-fce2-04fc-93b1" primary="true"/>
+        <categoryLink id="67bd-8c4f-eee0-401e" name="Troop" hidden="false" targetId="359c-fce2-04fc-93b1" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="e8bf-68a0-0aba-edd4" name="Teeth and Claws" hidden="false" collective="false" import="true" targetId="4762-b9e0-07f0-757a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a544-d772-c528-d760" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3771-440e-a149-8590" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a544-d772-c528-d760" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3771-440e-a149-8590" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="7.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="7"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7e40-0bb4-ea17-6cd8" name="Stage 3Z &apos;Zombie&apos;" hidden="false" collective="false" import="true" type="model">
@@ -180,18 +212,18 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="1996-7160-e933-0bbc" name="Horde" hidden="false" targetId="9b72-c451-cddf-4b0f" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6ff1-2d08-2ce0-7913" name="New CategoryLink" hidden="false" targetId="359c-fce2-04fc-93b1" primary="true"/>
+        <categoryLink id="6ff1-2d08-2ce0-7913" name="Troop" hidden="false" targetId="359c-fce2-04fc-93b1" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="7540-18be-4ba8-f4ba" name="Teeth and Claws" hidden="false" collective="false" import="true" targetId="85dd-b635-7f06-ca89" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bccd-ab89-3a47-81cf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dc7-3e69-72c9-7f81" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bccd-ab89-3a47-81cf" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dc7-3e69-72c9-7f81" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="6.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="6"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1f5a-7468-d0b1-68f1" name="Stage 2A &apos;Leaper&apos;" hidden="false" collective="false" import="true" type="model">
@@ -201,20 +233,20 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="8451-19ca-6325-52a6" name="Rampage" hidden="false" targetId="d5f6-f0d3-1597-02c3" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5560-27d3-a713-9655" name="New CategoryLink" hidden="false" targetId="359c-fce2-04fc-93b1" primary="true"/>
+        <categoryLink id="5560-27d3-a713-9655" name="Troop" hidden="false" targetId="359c-fce2-04fc-93b1" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="14b4-8acb-246a-0166" name="Teeth and Claws" hidden="false" collective="false" import="true" targetId="4762-b9e0-07f0-757a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c63-89f0-a4ea-6b11" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b025-6425-93a4-06c2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c63-89f0-a4ea-6b11" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b025-6425-93a4-06c2" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="7171-6efa-6ab7-9250" name="Equipment" hidden="false" collective="false" import="true" targetId="7ff8-5aa1-f173-1e4b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="16.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="16"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="41b1-62da-ab61-9ab6" name="Stage 3A &apos;Weapons Team&apos;" hidden="false" collective="false" import="true" type="model">
@@ -222,20 +254,20 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="9082-590b-2f7f-2fd1" name="Stage 3A &apos;Weapons Team&apos;" hidden="false" targetId="4def-0d03-e035-1212" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4173-55a0-3e69-d017" name="New CategoryLink" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
+        <categoryLink id="4173-55a0-3e69-d017" name="Specialist" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="cf94-f56b-6b34-9b6e" name="Mortar" hidden="false" collective="false" import="true" targetId="b7bf-564c-0e17-250a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7226-3e73-d3b5-1ee7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="541e-5568-772e-fc96" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7226-3e73-d3b5-1ee7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="541e-5568-772e-fc96" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="b5ea-f310-b4bb-b75c" name="Equipment" hidden="false" collective="false" import="true" targetId="7ff8-5aa1-f173-1e4b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="22.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="3.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="22"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="3"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fb9c-d97a-1f6e-aaf3" name="Murderbirds" hidden="false" collective="false" import="true" type="model">
@@ -245,19 +277,19 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="659c-2586-e646-e69f" name="Flight" hidden="false" targetId="eee1-3e1f-8b8b-8e38" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="38ae-abd7-421a-e8bb" name="New CategoryLink" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
+        <categoryLink id="38ae-abd7-421a-e8bb" name="Specialist" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="d2a3-757f-b066-fade" name="Beak and Talons" hidden="false" collective="false" import="true" targetId="c534-28bb-576f-b9bd" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="269e-add9-f235-63ef" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e4c-cd91-3361-d4fa" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="269e-add9-f235-63ef" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e4c-cd91-3361-d4fa" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="18.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="18"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="403a-eda5-5e0f-c3ea" name="Stage 2B &apos;Burster&apos;" hidden="false" collective="false" import="true" type="model">
@@ -266,20 +298,20 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="dd73-5405-a852-d807" name="BOOM! (n)" hidden="false" targetId="14f3-b8e4-aa43-c969" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="d867-695e-e2e0-00e0" name="New CategoryLink" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
+        <categoryLink id="d867-695e-e2e0-00e0" name="Specialist" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="13d2-9ec1-a0ce-e5b5" name="Pusburst" hidden="false" collective="false" import="true" targetId="27d2-37f8-2161-c27a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b72f-46f0-d26c-a6f5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09c8-8eea-3fae-daa2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b72f-46f0-d26c-a6f5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09c8-8eea-3fae-daa2" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="5bfd-0ab6-d9ad-3824" name="Equipment" hidden="false" collective="false" import="true" targetId="7ff8-5aa1-f173-1e4b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="14.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="14"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0200-6bf2-ac88-9ba8" name="Plague Teraton" hidden="false" collective="false" import="true" type="model">
@@ -289,20 +321,20 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="8cac-36ed-8e0e-6411" name="Tough" hidden="false" targetId="e030-816f-762d-cc23" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="902d-0fc4-5157-43a7" name="New CategoryLink" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
+        <categoryLink id="902d-0fc4-5157-43a7" name="Specialist" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="0f10-5b8b-675f-fca5" name="Claws" hidden="false" collective="false" import="true" targetId="02ed-4a7f-a2df-f6e2" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa6f-0434-eff4-9a5f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c13d-4dfa-7e29-ff04" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa6f-0434-eff4-9a5f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c13d-4dfa-7e29-ff04" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="4445-c546-4d38-c8a5" name="Equipment" hidden="false" collective="false" import="true" targetId="7ff8-5aa1-f173-1e4b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="24.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="3.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="24"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="3"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d12b-f74c-f5b5-0e64" name="Plague Swarm" hidden="false" collective="false" import="true" type="model">
@@ -313,19 +345,19 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="9252-0c72-9c86-f612" name="Beast" hidden="false" targetId="9dfa-4b05-f18a-4b11" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9c18-34ff-44aa-0be4" name="New CategoryLink" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
+        <categoryLink id="9c18-34ff-44aa-0be4" name="Specialist" hidden="false" targetId="e0b7-1823-fa7a-dfa6" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9e35-e60f-1a10-1aaf" name="Acidic Bite" hidden="false" collective="false" import="true" targetId="4da9-0bf7-f7fd-6801" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d53-8d70-a2f6-38e1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="126d-f477-d650-c61e" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d53-8d70-a2f6-38e1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="126d-f477-d650-c61e" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="20.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="20"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9bfe-567b-809d-0b33" name="Urban Assault Strider" hidden="false" collective="false" import="true" type="model">
@@ -335,35 +367,35 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="8f0e-6a43-19c9-2338" name="Vehicle" hidden="false" targetId="bd02-8a7f-60ba-dbb5" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="92c1-50e8-213e-ffd5" name="New CategoryLink" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
+        <categoryLink id="92c1-50e8-213e-ffd5" name="Support" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="4774-ffb4-bb90-a7c2" name="Chainsaw" hidden="false" collective="false" import="true" targetId="0309-0e31-547e-5418" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7379-81ec-c04f-498f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e2a-5d06-780b-2f09" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7379-81ec-c04f-498f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e2a-5d06-780b-2f09" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="2a52-b0e1-d97f-ea06" name="Assault Flamer" hidden="false" collective="false" import="true" targetId="75f3-f4a1-6de8-904a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2233-02f1-8a00-9a12" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c651-e23e-1090-6a45" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2233-02f1-8a00-9a12" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c651-e23e-1090-6a45" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="18d4-7edd-a2bc-b555" name="Shoulder Rockets" hidden="false" collective="false" import="true" targetId="354e-b1e3-6938-c041" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e54-c8fc-aaab-0c1e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e54-c8fc-aaab-0c1e" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="0e8a-e622-1ff4-fe5d" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="f915-7f79-ace2-c18c" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cdc-2ba4-d263-aa89" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cdc-2ba4-d263-aa89" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="44.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="5.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="44"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ad09-5335-47c8-1cf3" name="Heavy Support Strider" hidden="false" collective="false" import="true" type="model">
@@ -373,29 +405,29 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="a333-4cd7-867c-bb2f" name="Vehicle" hidden="false" targetId="bd02-8a7f-60ba-dbb5" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b013-3d1d-0876-6ab5" name="New CategoryLink" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
+        <categoryLink id="b013-3d1d-0876-6ab5" name="Support" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="bc87-8fbd-b018-ecb2" name="Heavy Burst Laser" hidden="false" collective="false" import="true" targetId="e0c7-535a-a191-3495" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a81-1b5a-cffa-2976" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be48-7dec-d772-73fe" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a81-1b5a-cffa-2976" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be48-7dec-d772-73fe" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="4452-0cfb-d06d-a101" name="Shoulder Rockets" hidden="false" collective="false" import="true" targetId="354e-b1e3-6938-c041" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e6e-98f6-f501-d60a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e6e-98f6-f501-d60a" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="e74b-f419-5dbb-c3f6" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="f915-7f79-ace2-c18c" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99af-f814-c067-cfdb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99af-f814-c067-cfdb" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="40.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="40"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1d60-9274-183f-1ce6" name="Tank Buster Strider" hidden="false" collective="false" import="true" type="model">
@@ -405,29 +437,29 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="5008-1b20-627d-1409" name="Vehicle" hidden="false" targetId="bd02-8a7f-60ba-dbb5" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9f1b-3492-0347-a8f5" name="New CategoryLink" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
+        <categoryLink id="9f1b-3492-0347-a8f5" name="Support" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="d55f-cf95-5b67-698e" name="Polaris Cannon" hidden="false" collective="false" import="true" targetId="ad7b-e0c2-26f5-fb2b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca7-e263-abce-fe52" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f509-9d1c-951c-0187" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca7-e263-abce-fe52" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f509-9d1c-951c-0187" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="df6c-9fea-de1f-e622" name="Shoulder Rockets" hidden="false" collective="false" import="true" targetId="354e-b1e3-6938-c041" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9517-10fc-9353-17ca" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9517-10fc-9353-17ca" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="5411-a92c-7f85-72bb" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="f915-7f79-ace2-c18c" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf28-35d7-c5d8-30df" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf28-35d7-c5d8-30df" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="42.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="42"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2029-1c44-f22c-b8d4" name="Aberration" hidden="false" collective="false" import="true" type="model">
@@ -439,19 +471,19 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="7009-f14c-a826-0991" name="Rampage" hidden="false" targetId="d5f6-f0d3-1597-02c3" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4d24-d360-67d7-7ac8" name="New CategoryLink" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
+        <categoryLink id="4d24-d360-67d7-7ac8" name="Support" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="7632-209b-a895-b014" name="Teeth and Claws" hidden="false" collective="false" import="true" targetId="408e-ccb2-5ed2-e91a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="570f-fa4a-2074-b8bf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f1d-7bf7-43a4-43f4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="570f-fa4a-2074-b8bf" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f1d-7bf7-43a4-43f4" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="40.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="40"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7f6c-b2c6-d317-b1ec" name="Corruption" hidden="false" collective="false" import="true" type="model">
@@ -460,36 +492,36 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="0c83-a1bf-cc29-92b9" name="Beast" hidden="false" targetId="9dfa-4b05-f18a-4b11" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="de17-0066-3e6e-8b1d" name="New CategoryLink" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
+        <categoryLink id="de17-0066-3e6e-8b1d" name="Support" hidden="false" targetId="1364-5634-04d6-8af7" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="6a2f-67ef-728e-f977" name="Club" hidden="false" collective="false" import="true" targetId="067b-4a43-6747-8f9f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f30d-563d-214a-e1aa" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d541-6180-cbb8-57b0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f30d-563d-214a-e1aa" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d541-6180-cbb8-57b0" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="3b91-2b04-814c-8d46" name="Vicious Claws" hidden="false" collective="false" import="true" targetId="d3be-5cd5-ebf5-5644" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8434-d7a5-38bb-bd95" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33b3-f5ce-bec6-8543" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8434-d7a5-38bb-bd95" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33b3-f5ce-bec6-8543" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="80ef-0265-1889-9273" name="Wicked Blade" hidden="false" collective="false" import="true" targetId="1bb5-c866-f616-c93b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a82-9900-1468-3bc2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf7a-f0e9-d71f-8bca" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a82-9900-1468-3bc2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf7a-f0e9-d71f-8bca" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="44.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="44"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="4"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="284c-5a22-ae37-d467" name="Subject 901" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="93e5-130c-bf8f-af4a" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="93e5-130c-bf8f-af4a" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="0f74-a28b-a079-9a40" name="Subject 901" hidden="false" targetId="2a90-83cb-00e5-2f4f" type="profile"/>
@@ -497,24 +529,24 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="0649-dbd6-2c5a-b975" name="Tactician (n)" hidden="false" targetId="2249-d210-753f-645c" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ed11-5936-e3ca-aa4d" name="New CategoryLink" hidden="false" targetId="c049-07ca-32fa-da63" primary="true"/>
+        <categoryLink id="ed11-5936-e3ca-aa4d" name="Living Legend" hidden="false" targetId="c049-07ca-32fa-da63" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="a51d-47a0-465c-e983" name="Teeth and Claws" hidden="false" collective="false" import="true" targetId="65d7-28fb-8c50-b378" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d32-6f7f-0447-249f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55f2-1022-1321-ea46" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d32-6f7f-0447-249f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55f2-1022-1321-ea46" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="24.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="3.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="24"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="3"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d2ed-4101-dcd2-0256" name="Doctor Gayle Simmonds" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a972-5cdc-9fca-85a0" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a972-5cdc-9fca-85a0" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="290f-2e20-51f9-263a" name="Doctor Gayle Simmonds" hidden="false" targetId="dfff-9ddd-5586-cf52" type="profile"/>
@@ -523,20 +555,69 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="e6c8-ce6e-9646-8403" name="Tough" hidden="false" targetId="e030-816f-762d-cc23" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b65f-61b3-6f25-93d6" name="New CategoryLink" hidden="false" targetId="c049-07ca-32fa-da63" primary="true"/>
+        <categoryLink id="b65f-61b3-6f25-93d6" name="Living Legend" hidden="false" targetId="c049-07ca-32fa-da63" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="97d9-5e72-561b-0f9c" name="Pistol" hidden="false" collective="false" import="true" targetId="c650-a3cb-6a61-4736" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbbd-3757-6d63-9b23" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a4c-2a35-0462-1748" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbbd-3757-6d63-9b23" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a4c-2a35-0462-1748" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="18.0"/>
-        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="18"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="2"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Stage 3A &apos;Crusher&apos;" hidden="false" id="252b-d8d9-f88a-a263">
+      <costs>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="16"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Equipment" hidden="false" id="0493-da9d-e531-029b" type="selectionEntryGroup" targetId="7ff8-5aa1-f173-1e4b"/>
+        <entryLink import="true" name="Energy Flail" hidden="false" id="c13e-b6e4-3d67-cf63" type="selectionEntry" targetId="4032-3b1d-1dff-3414">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7347-c1cd-e1a4-7638-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7347-c1cd-e1a4-7638-max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <infoLinks>
+        <infoLink name="Defender Shield" id="577e-bb16-5d03-c367" hidden="false" type="rule" targetId="db2d-083d-54bb-2def"/>
+        <infoLink name="Stage 3A &apos;Crusher&apos;" id="88ef-e08f-ea6b-f0b2" hidden="false" type="profile" targetId="3535-4f23-00f9-097e"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink targetId="e0b7-1823-fa7a-dfa6" id="0ad1-2e65-18b9-7cc7" primary="true" name="Specialist"/>
+      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Stage 3A Monocycle &apos;Blitzer&apos;" hidden="false" id="8105-3041-e8cb-2402">
+      <costs>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="14"/>
+        <cost name=" VP" typeId="37c4-cdb6-d837-e224" value="1"/>
+      </costs>
+      <infoLinks>
+        <infoLink name="Stage 3A Monocycle &apos;Blitzer&apos;" id="ee0c-769c-82b9-127c" hidden="false" type="profile" targetId="d90a-cc65-6c94-f143"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink import="true" name="Equipment" hidden="false" id="99af-4c6e-3430-e595" type="selectionEntryGroup" targetId="7ff8-5aa1-f173-1e4b"/>
+        <entryLink import="true" name="Combat Chains" hidden="false" id="084d-7363-c7fd-ccdb" type="selectionEntry" targetId="a6c9-9c4e-749b-6e75">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e0b6-783a-61f5-93c6-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e0b6-783a-61f5-93c6-max"/>
+          </constraints>
+        </entryLink>
+        <entryLink import="true" name="Pox Bomb" hidden="false" id="7ec4-49da-8f5f-d3bd" type="selectionEntry" targetId="faec-30a9-7073-2dda">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="287d-bc44-88a2-4127-min"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="287d-bc44-88a2-4127-max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <categoryLinks>
+        <categoryLink targetId="e0b7-1823-fa7a-dfa6" id="e343-0249-c336-40cd" primary="true" name="Specialist"/>
+      </categoryLinks>
     </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntries>
@@ -608,7 +689,7 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="598c-6ea5-16f2-6ffc" name="One-Use" hidden="false" targetId="401b-9df8-8946-4135" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="6.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="6"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="87b3-96a5-3e35-5725" name="Rifle" hidden="false" collective="false" import="true" type="upgrade">
@@ -696,7 +777,7 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="4a6d-095f-67a4-1298" name="One-Use" hidden="false" targetId="401b-9df8-8946-4135" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="3.0"/>
+        <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="3"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="65d7-28fb-8c50-b378" name="Teeth and Claws" hidden="false" collective="false" import="true" type="upgrade">
@@ -704,39 +785,76 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <infoLink id="dc7a-01a6-9c01-9ed7" name="Teeth and Claws" hidden="false" targetId="49e1-130b-7d15-a8a9" type="profile"/>
       </infoLinks>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Metal Bar" hidden="false" id="26ac-9f96-f3bd-8cac">
+      <infoLinks>
+        <infoLink name="Knockback" id="9f67-2c5b-53ce-db30" hidden="false" type="rule" targetId="bddf-77c1-55be-e183"/>
+        <infoLink name="Metal Bar" id="d954-a6ec-8607-03b2" hidden="false" type="profile" targetId="497c-0e9c-56d0-4997"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Vicious Two-Hander" hidden="false" id="6fb2-9f96-0dfd-4b73">
+      <infoLinks>
+        <infoLink name="Vicious Two-Hander" id="d8e6-2c68-9902-a2b5" hidden="false" type="profile" targetId="3376-b52d-9054-4152"/>
+        <infoLink name="Smash (n)" id="06b6-d6c4-2a87-4b0f" hidden="false" type="rule" targetId="3948-3af5-4928-3965"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Pox Bomb" hidden="false" id="faec-30a9-7073-2dda">
+      <infoLinks>
+        <infoLink name="Pox Bomb" id="9ded-50e1-6e87-89f5" hidden="false" type="profile" targetId="e398-b951-62ca-f46c"/>
+        <infoLink name="Frag (n)" id="e515-b0d5-06c5-71c9" hidden="false" type="rule" targetId="af4a-32a8-dd1e-ee74"/>
+        <infoLink name="Gas Cloud (Toxic (n))" id="d8b8-ad61-e7b0-53b8" hidden="false" type="rule" targetId="b195-5d2d-f3da-1a4d"/>
+        <infoLink name="Grenade" id="da17-7e2d-19c7-2a2e" hidden="false" type="rule" targetId="34c6-c132-53f6-00a9"/>
+        <infoLink name="One-Use" id="809f-cf37-e6eb-7609" hidden="false" type="rule" targetId="401b-9df8-8946-4135"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Energy Flail" hidden="false" id="4032-3b1d-1dff-3414">
+      <infoLinks>
+        <infoLink name="Energy Flail" id="6f45-b3b8-b68d-a4e1" hidden="false" type="profile" targetId="951b-eddd-25d5-6bee"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Defender Shield" hidden="false" id="0fb3-8c66-8643-5557">
+      <infoLinks>
+        <infoLink name="Defender Shield" id="b473-c753-f483-2f1a" hidden="false" type="rule" targetId="db2d-083d-54bb-2def"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Combat Chains" hidden="false" id="a6c9-9c4e-749b-6e75">
+      <infoLinks>
+        <infoLink name="Combat Chains" id="d450-0227-60cf-fa4b" hidden="false" type="profile" targetId="24e7-9af2-85ff-2d84"/>
+        <infoLink name="Frenzy (n)" id="aaa6-29e2-ec8e-946d" hidden="false" type="rule" targetId="a027-b66a-6884-847b"/>
+      </infoLinks>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="7ff8-5aa1-f173-1e4b" name="Equipment" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c82-ad67-81db-6fa2" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c82-ad67-81db-6fa2" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="a421-26dc-3e51-4519" name="Ammo" hidden="false" collective="false" import="true" targetId="c275-654b-b7c4-f92d" type="selectionEntry">
           <costs>
-            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="2.0"/>
+            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="2"/>
           </costs>
         </entryLink>
         <entryLink id="88a3-fec9-0dc9-a2e3" name="AP Ammo" hidden="false" collective="false" import="true" targetId="ae96-884e-4c50-fd84" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3274-f86d-bac3-fad6" type="max"/>
+            <constraint field="selections" scope="roster" value="4" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3274-f86d-bac3-fad6" type="max"/>
           </constraints>
           <costs>
-            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="4.0"/>
+            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="4"/>
           </costs>
         </entryLink>
         <entryLink id="4a43-b736-0a8b-6e4d" name="Grenade (Frag (3))" hidden="false" collective="false" import="true" targetId="ffd5-4d16-3edf-5df5" type="selectionEntry">
           <costs>
-            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="6.0"/>
+            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="6"/>
           </costs>
         </entryLink>
         <entryLink id="e661-04be-6d1f-7d34" name="Grenade (Smoke)" hidden="false" collective="false" import="true" targetId="23b2-fe72-6f20-d935" type="selectionEntry">
           <costs>
-            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="3.0"/>
+            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="3"/>
           </costs>
         </entryLink>
         <entryLink id="4702-93cb-e41d-266f" name="Combat Blades" hidden="false" collective="false" import="true" targetId="73b1-24e3-20e7-5287" type="selectionEntry">
           <costs>
-            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="2.0"/>
+            <cost name=" Pts" typeId="69b0-482f-35d5-9309" value="2"/>
           </costs>
         </entryLink>
       </entryLinks>
@@ -1148,6 +1266,74 @@ Please consider supporting Mantic by purchasing a subscription to the EasyArmy a
         <characteristic name="Range" typeId="4fec-80ed-f364-651e">CC</characteristic>
         <characteristic name="AP" typeId="b83c-4711-2641-5adc">AP1</characteristic>
         <characteristic name="Keywords" typeId="5f44-a8dd-9156-8d05">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Metal Bar" typeId="79ae-b2a0-6216-4a64" typeName="Weapon" hidden="false" id="497c-0e9c-56d0-4997">
+      <characteristics>
+        <characteristic name="Range" typeId="4fec-80ed-f364-651e">CC</characteristic>
+        <characteristic name="AP" typeId="b83c-4711-2641-5adc"/>
+        <characteristic name="Keywords" typeId="5f44-a8dd-9156-8d05">Knockback</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Vicious Two-Hander" typeId="79ae-b2a0-6216-4a64" typeName="Weapon" hidden="false" id="3376-b52d-9054-4152">
+      <characteristics>
+        <characteristic name="Range" typeId="4fec-80ed-f364-651e">CC</characteristic>
+        <characteristic name="AP" typeId="b83c-4711-2641-5adc">1</characteristic>
+        <characteristic name="Keywords" typeId="5f44-a8dd-9156-8d05">Smash (1)</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Pox Bomb" typeId="79ae-b2a0-6216-4a64" typeName="Weapon" hidden="false" id="e398-b951-62ca-f46c">
+      <characteristics>
+        <characteristic name="Range" typeId="4fec-80ed-f364-651e">R2</characteristic>
+        <characteristic name="AP" typeId="b83c-4711-2641-5adc"/>
+        <characteristic name="Keywords" typeId="5f44-a8dd-9156-8d05">Frag (2), Gas Cloud - Toxic (1), Grenade, One-Use</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Tools" typeId="79ae-b2a0-6216-4a64" typeName="Weapon" hidden="false" id="7147-9f95-5fb4-c5a0">
+      <characteristics>
+        <characteristic name="Range" typeId="4fec-80ed-f364-651e">CC</characteristic>
+        <characteristic name="AP" typeId="b83c-4711-2641-5adc"/>
+        <characteristic name="Keywords" typeId="5f44-a8dd-9156-8d05">Engineer</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Energy Flail" typeId="79ae-b2a0-6216-4a64" typeName="Weapon" hidden="false" id="951b-eddd-25d5-6bee">
+      <characteristics>
+        <characteristic name="Range" typeId="4fec-80ed-f364-651e">CC</characteristic>
+        <characteristic name="AP" typeId="b83c-4711-2641-5adc">2</characteristic>
+        <characteristic name="Keywords" typeId="5f44-a8dd-9156-8d05"/>
+      </characteristics>
+    </profile>
+    <profile name="Stage 3A &apos;Crusher&apos;" typeId="69a2-9cae-5bf4-dc2d" typeName="Model" hidden="false" id="3535-4f23-00f9-097e">
+      <characteristics>
+        <characteristic name="SP" typeId="60d9-72b8-b674-250f">2-3</characteristic>
+        <characteristic name="RA" typeId="b27f-05a1-d5c3-6c25">6+</characteristic>
+        <characteristic name="FI" typeId="f4e2-8366-8c5f-d74d">4+</characteristic>
+        <characteristic name="SV" typeId="beab-fc63-a14f-0242">5+</characteristic>
+        <characteristic name="AR" typeId="666f-6b0b-f8f0-5954">-</characteristic>
+        <characteristic name="HP" typeId="63bb-c9e5-0126-03bb">2</characteristic>
+        <characteristic name="SZ" typeId="ef53-2622-e772-f4b4">1</characteristic>
+        <characteristic name="Base" typeId="2df5-8371-3046-feef">25mm</characteristic>
+        <characteristic name="Abilities" typeId="df9b-440a-5556-92eb">Defender Shield</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Stage 3A Monocycle &apos;Blitzer&apos;" typeId="69a2-9cae-5bf4-dc2d" typeName="Model" hidden="false" id="d90a-cc65-6c94-f143">
+      <characteristics>
+        <characteristic name="SP" typeId="60d9-72b8-b674-250f">2-5</characteristic>
+        <characteristic name="RA" typeId="b27f-05a1-d5c3-6c25">6+</characteristic>
+        <characteristic name="FI" typeId="f4e2-8366-8c5f-d74d">5+</characteristic>
+        <characteristic name="SV" typeId="beab-fc63-a14f-0242">5+</characteristic>
+        <characteristic name="AR" typeId="666f-6b0b-f8f0-5954">-</characteristic>
+        <characteristic name="HP" typeId="63bb-c9e5-0126-03bb">2</characteristic>
+        <characteristic name="SZ" typeId="ef53-2622-e772-f4b4">1</characteristic>
+        <characteristic name="Base" typeId="2df5-8371-3046-feef">40mm</characteristic>
+        <characteristic name="Abilities" typeId="df9b-440a-5556-92eb">Bike</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Combat Chains" typeId="79ae-b2a0-6216-4a64" typeName="Weapon" hidden="false" id="24e7-9af2-85ff-2d84">
+      <characteristics>
+        <characteristic name="Range" typeId="4fec-80ed-f364-651e">CC</characteristic>
+        <characteristic name="AP" typeId="b83c-4711-2641-5adc"/>
+        <characteristic name="Keywords" typeId="5f44-a8dd-9156-8d05">Frenzy (1)</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Fixes https://github.com/BSData/deadzone/issues/57 and adds new units from the Mantic Companion:
* Ghoul Troops: Metal bar and Vicious Two-Hander
* Ghoul Specialist: Pox Bomb
* Stage 3A 'Crusher'
* Stage 3A Monocycle 'Blitzer'

Changes made with the 'New Recruit - Editor', which I am new to using, but testing them in the 'New Recruit - Builder' seems to be correct.